### PR TITLE
퍼즐 오류 수정

### DIFF
--- a/Assets/01.Scripts/01.ThreeMatch/PuzzleGenerator.cs
+++ b/Assets/01.Scripts/01.ThreeMatch/PuzzleGenerator.cs
@@ -690,6 +690,15 @@ namespace _01.Scripts._01.ThreeMatch
             if (_puzzles[x1, y1] is ObstaclePuzzleObject || _puzzles[x2, y2] is ObstaclePuzzleObject
                 || (maxSwapCount != -1 && _swapCount >= maxSwapCount))
             {
+                if (_puzzles[x1, y1] is SpecialPuzzleObject sp1)
+                {
+                    sp1.isBlocked = true;
+                }
+                if (_puzzles[x2, y2] is SpecialPuzzleObject sp2)
+                {
+                    sp2.isBlocked = true;
+                }
+                
                 _puzzles[x1, y1].FailedSwapEffect(x2 - x1, y2 - y1, 
                     Vector2.Distance(_puzzles[x1, y1].transform.position, _puzzles[x2, y2].transform.position) / 2);
                 return;

--- a/Assets/01.Scripts/01.ThreeMatch/SpecialPuzzleObject.cs
+++ b/Assets/01.Scripts/01.ThreeMatch/SpecialPuzzleObject.cs
@@ -7,6 +7,7 @@ namespace _01.Scripts._01.ThreeMatch
     {
         public SpecialPuzzleType specialPuzzleType;
         public Habitat habitat;
+        public bool isBlocked;
 
         public override int GetPuzzleSubType() => (int)specialPuzzleType;
         
@@ -14,6 +15,12 @@ namespace _01.Scripts._01.ThreeMatch
         {
             if (Generator.IsProcessing)
             {
+                return;
+            }
+
+            if (isBlocked)
+            {
+                isBlocked = false;
                 return;
             }
             

--- a/Assets/01.Scripts/10.System/Combo/DesertCombo.cs
+++ b/Assets/01.Scripts/10.System/Combo/DesertCombo.cs
@@ -11,7 +11,9 @@ namespace _01.Scripts._10.System.Combo
         {
             for (int i = 0; i < 1 + ((GameManager.Instance.comboData.comboLevels[info.comboType] - 1) / 2); i++)
             {
-                context.Puzzle.SpawnSpecialPuzzle(SpecialPuzzleType.RowBomb);
+                SpecialPuzzleType randomType =
+                    Random.value < 0.5f ? SpecialPuzzleType.RowBomb : SpecialPuzzleType.ColumnBomb; 
+                context.Puzzle.SpawnSpecialPuzzle(randomType);
             }
         }
 


### PR DESCRIPTION
closed #107 

### 설명
- 특수타일 아이템 사용 시 행/열 폭탄이 랜덤으로 나오게 수정
- 특수타일을 장애물 타일쪽으로 이동 시 발동되는 오류 수정

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
